### PR TITLE
Allow custom root variable and add tree search

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,10 @@
         <!-- path bar -->
         <div id="reader-path-bar-holder">
           <div id="reader-path-bar">
+            <div id="reader-root-var-label" class="reader-path-bar-item">
+              Var:
+            </div>
+            <input id="reader-root-var-input" class="reader-path-bar-item" />
             <div id="reader-path-bar-label" class="reader-path-bar-item">
               Path:
             </div>
@@ -81,6 +85,15 @@
               readonly
             />
             <button disabled id="reader-path-bar-copy">Copy</button>
+            <div id="reader-search-label" class="reader-path-bar-item">
+              Search:
+            </div>
+            <input
+              id="reader-search-input"
+              class="reader-path-bar-item"
+              placeholder="Search"
+            />
+            <button disabled id="reader-search-clear">Clear</button>
           </div>
         </div>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,8 @@ import {
   initBeautifyButton,
   initMinifyButton,
 } from "./editor";
-import { initPathDisplay, initCopyButton } from "./path-bar";
+import { initPathDisplay, initCopyButton, initRootVar } from "./path-bar";
+import { initSearch } from "./search";
 import { initVersion2Overlay } from "./overlay";
 import { initBigBoxes } from "./big-boxes";
 import { setUpLocalStorage } from "./storage";
@@ -21,6 +22,8 @@ document.addEventListener("DOMContentLoaded", () => {
   initEditor(appState);
   initPathDisplay(appState);
   initCopyButton(appState);
+  initRootVar(appState);
+  initSearch(appState);
   initDarkMode(appState);
   initSampleButton(appState);
   initBeautifyButton(appState);

--- a/src/path-bar.ts
+++ b/src/path-bar.ts
@@ -43,3 +43,24 @@ export function initCopyButton(state: AppState) {
     }, 1000);
   });
 }
+
+export function initRootVar(state: AppState) {
+  const rootVarInput = document.querySelector<HTMLInputElement>(
+    "#reader-root-var-input",
+  );
+  if (!rootVarInput) return;
+
+  rootVarInput.value = state.get("rootVar");
+
+  rootVarInput.addEventListener("input", () => {
+    state.set("rootVar", rootVarInput.value);
+  });
+
+  state.subscribe("rootVar", "update root var and path", (newVar, lastVar) => {
+    rootVarInput.value = newVar;
+    const currentPath = state.get("path");
+    if (currentPath.startsWith(lastVar)) {
+      state.set("path", `${newVar}${currentPath.slice(lastVar.length)}`);
+    }
+  });
+}

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -29,20 +29,22 @@ export class Reader {
     return value === null || value === undefined || typeof value !== "object";
   }
 
-  private static appendKeyToPath(key: string | number, path: string) {
+  private appendKeyToPath(key: string | number, path: string) {
+    const basePath = path || this.state.get("rootVar");
+
     if (Number.isInteger(key)) {
-      return `${path}[${key.toString()}]`;
+      return `${basePath}[${key.toString()}]`;
     }
 
     if (/[^A-Za-z0-9_$]/.test(key.toString())) {
-      return `${path}["${key}"]`;
+      return `${basePath}["${key}"]`;
     }
 
-    return `${path}.${key}`;
+    return `${basePath}.${key}`;
   }
 
   private renderLeafNode({ key, value, path }: RenderLeafNodeParam) {
-    const newPath = Reader.appendKeyToPath(key, path);
+    const newPath = this.appendKeyToPath(key, path);
 
     const button = document.createElement("button");
     button.classList.add("json-reader-tree-property");
@@ -64,7 +66,7 @@ export class Reader {
   }
 
   private renderParentNode({ key, value, path }: RenderParentParam) {
-    const newPath = Reader.appendKeyToPath(key, path);
+    const newPath = this.appendKeyToPath(key, path);
 
     const details = document.createElement("details");
 
@@ -89,10 +91,7 @@ export class Reader {
     return details;
   }
 
-  private renderTree(
-    obj: JSONObjOrArr,
-    { path = "x", isSubtree = false } = {},
-  ) {
+  private renderTree(obj: JSONObjOrArr, { path = "", isSubtree = false } = {}) {
     const entries = toEntries(obj);
 
     const rootDiv = document.createElement("div");

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,0 +1,59 @@
+import { debounce } from "./helpers";
+import { type AppState } from "./state";
+
+export function initSearch(state: AppState) {
+  const searchInput = document.querySelector<HTMLInputElement>(
+    "#reader-search-input",
+  );
+  const clearButton = document.getElementById("reader-search-clear");
+  if (!searchInput || !clearButton) return;
+
+  const highlightClass = "json-reader-search-highlight";
+
+  const runSearch = (query: string) => {
+    document
+      .querySelectorAll<HTMLElement>(`.${highlightClass}`)
+      .forEach((el) => el.classList.remove(highlightClass));
+
+    if (!query) {
+      clearButton.setAttribute("disabled", "");
+      return;
+    }
+
+    clearButton.removeAttribute("disabled");
+    const lowerQuery = query.toLowerCase();
+
+    document
+      .querySelectorAll<HTMLElement>(
+        ".json-reader-tree-parent, .json-reader-tree-property",
+      )
+      .forEach((el) => {
+        if (el.textContent?.toLowerCase().includes(lowerQuery)) {
+          el.classList.add(highlightClass);
+          let parent: HTMLElement | null = el.parentElement;
+          while (parent) {
+            if (parent.tagName === "DETAILS") {
+              (parent as HTMLDetailsElement).open = true;
+            }
+            parent = parent.parentElement;
+          }
+        }
+      });
+  };
+
+  const debouncedSearch = debounce((value: string) => runSearch(value), 200);
+
+  searchInput.addEventListener("input", () => {
+    debouncedSearch(searchInput.value);
+  });
+
+  clearButton.addEventListener("click", () => {
+    searchInput.value = "";
+    runSearch("");
+    searchInput.focus();
+  });
+
+  state.subscribe("jsonText", "re-run search when data changes", () => {
+    runSearch(searchInput.value);
+  });
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -82,6 +82,7 @@ type InitialState = {
   isDarkMode: boolean;
   jsonText: string;
   path: string;
+  rootVar: string;
   copyButtonDisabled: boolean;
   error: string;
   selectedNode: HTMLElement | null;
@@ -99,6 +100,7 @@ const initialState: InitialState = {
   isDarkMode: false,
   jsonText: JSON.stringify(initialJsonData, null, 2),
   path: "",
+  rootVar: "x",
   copyButtonDisabled: false,
   error: "",
   selectedNode: null,

--- a/src/style.css
+++ b/src/style.css
@@ -142,6 +142,12 @@ p {
   border-right: 1px solid #ccc;
 }
 
+#reader-root-var-label {
+  align-items: center;
+  display: flex;
+  border-right: 1px solid #ccc;
+}
+
 #reader-path-bar-input {
   color: #455a64;
   flex: 1;
@@ -149,11 +155,39 @@ p {
   font-size: 0.9em;
 }
 
+#reader-root-var-input {
+  color: #455a64;
+  font-family: "Roboto Mono", monospace;
+  font-size: 0.9em;
+  width: 60px;
+}
+
 #reader-path-bar-copy {
   background-color: white;
   border-left: 1px solid #ccc;
   height: 25px;
   width: 70px;
+}
+
+#reader-search-label {
+  align-items: center;
+  display: flex;
+  border-left: 1px solid #ccc;
+  border-right: 1px solid #ccc;
+}
+
+#reader-search-input {
+  color: #455a64;
+  font-family: "Roboto Mono", monospace;
+  font-size: 0.9em;
+  width: 160px;
+}
+
+#reader-search-clear {
+  background-color: white;
+  border-left: 1px solid #ccc;
+  height: 25px;
+  width: 60px;
 }
 
 /* the JSON reader itself */
@@ -225,6 +259,10 @@ p {
 
 .json-reader-tree-property-selected {
   background-color: #c1d5e0;
+}
+
+.json-reader-search-highlight {
+  background-color: #fff9c4;
 }
 
 /* footer */


### PR DESCRIPTION
## Summary
- add `rootVar` state with default `x`
- expose input to edit root variable in the path bar
- generate and display paths using the chosen variable
- add a search bar with clear button to filter tree nodes
- highlight matched nodes and expand parents during search

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689ae86c3af0832a90ad82c83803a213